### PR TITLE
[FIX] requirements.txt: Fixed kiwi-gtk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 # needed to run stoqdrivers, they are processed by pip/easy_install
 #
 
-kiwi-gtk >= 1.9.41
+kiwi-gtk==1.9.41.post1
 zope.interface >= 3.0
 pyserial >= 2.2


### PR DESCRIPTION
Latest version of kiwi library not worked properly when fiscal printer module was loaded. Fixed to version: 1.9.41.post1 last known version that work.
