### PR TITLE
[REF] mp4000.py: set '0' as default coo to open credit note

### DIFF
--- a/stoqdrivers/printers/bematech/MP4000.py
+++ b/stoqdrivers/printers/bematech/MP4000.py
@@ -124,7 +124,7 @@ class MP4000(MP25):
                            (self._customer_name, self.get_serial(),
                             self._customer_document,
                             datetime.date.today().strftime('%d%m%y%H%M%S'),
-                            coo))
+                            coo or 0))
 
     def coupon_add_item(self, code, description, price, taxcode,
                         quantity=Decimal("1.0"), unit=UnitType.EMPTY,


### PR DESCRIPTION
Summary
-------------
When is called to open a credit note and it does not has a coo related is set by default '0', in order to allow print credit notes without invoice related